### PR TITLE
Memory fix + various launcher improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 Isn't it fun to have a nice GPU in your computer and to experiment left and right? You just write some python scripts
 and then launch them on your machine, wait, repeat. Life is simple and beautiful.
 
-But then inevitably it happens. 
+But then inevitably it happens. You want to launch more scripts, longer scripts, test different parameters... 
 
-You want to launch more scripts, longer scripts, test different parameters... 
-So you have to go beg the SLURM gods to assist you.
-Evil bash scripts start popping up everywhere, requesting resources, launching jobs....
+So you have to go beg the SLURM gods to assist you. Evil bash scripts start popping up everywhere, requesting resources, launching jobs....
+
 Wouldn't it be nice to just abstract that pain away and remain in python land?
 
 ## Prerequisites
@@ -26,12 +25,19 @@ $  conda create -n <env-name> -c conda-forge -c pytorch python=3.9 psutil pynvml
 You may want to check [here](https://pytorch.org/get-started/locally/) to confirm the pytorch installation procedure is
 correct for your GPU and NVIDIA driver.
 
+We also recommend that you add the `neuromanager/` folder to your `PATH`, so you can call these tools easily from the
+command line.
+```shell
+export PATH=$HOME/scratch/neuromanager:$PATH  # ... or wherever your neuromanager repo lives
+```
+
 ## [launcher](launcher)
-Allows you to turn
-```python
+
+This is a wrapper around `sbatch` to make it way easier to launch python scripts quickly. It allows you to turn:
+```shell
 python train.py --lr=0.01
 ```
-into
+into something like:
 ```bash
 #!/bin/bash
 #SBATCH --time=2-00:00:00
@@ -43,12 +49,102 @@ into
 conda activate deep
 python train.py --lr=0.01
 ```
-It has the following syntax
+Even better, it makes it easy to launch parameter sweeps as a job array.
+
+### Basic Usage
+
+It has the following syntax:
 ```
-launcher {--runs} CONFIG SCRIPT FLAGS
+launcher [-h] [--runs RUNS] [--argfile ARGFILE] [-d RUNDIR] [-f] RESOURCE SCRIPT [FLAGS...]
 ```
-where support/device information needs to be provided by ```config.json``` with the following structure
+where `RESOURCE` is the name of an entry in `config.json` (see [Resource Configurations](#resource-configurations)).
+
+For example, this:
+```shell
+launcher moran-gpu --runs 2 dummy_gpujob.py --epochs=10 --seed 42
 ```
+is equivalent to twice running this:
+```shell
+python dummy_gpujob.py --epochs=10 --seed 42
+```
+
+Furthermore, any settings accepted by `sbatch` may be supplied on the command line. These will override the options
+provided by `config.json`, if given. For example, to add more memory to an existing config:
+```
+launcher dggpu --mem=64G dummy_gpujob.py
+```
+**NOTE:** The `sbatch` options must be supplied in `--name=value` fashion, with an
+equals sign; `--name value` will *not* parse correctly. For any other options
+(including script flags) you may use either format.
+
+### Run Directory
+
+A recommended way to run jobs is to isolate different experiments to separate folders, so that all the related inputs
+and outputs can be stored in one place. This can be done with the `-d/--rundir` option:
+```shell
+launcher dggpu -d experiments/my-next-breakthrough train.py --config train-config.yml
+```
+In this example, all experiments are stored in the corresponding repository, under the `experiments/` folder. The script
+runs in this folder, where it expects to find a `train-config.yml` file. Say the script also generates a
+`trained_models/` folder. After running, the experiment folder will contain:
+```
+__ experiments/my-next-breakthrough/
+  |__ train-config.yml
+  |__ slurm-12345678.out
+  |__ trained_models/
+     |__ model-1000.pth
+     |__ model-2000.pth
+     |__ ...
+```
+
+### Running Job Arrays
+
+`launcher` can also run a full sweep of jobs as a single job array.
+
+> :warning: **Careful with program outputs when using this method!**
+> For instance, if you are running a program that outputs trained models, you will need to supply each run with a
+> separate output folder so they don't overwrite each other.
+
+You can run the same exact job N times via `-r/--runs`:
+```shell
+launcher bdgpu --runs 10 eval.py --lr 0.01 --num-steps 10 --plots
+```
+
+Or you can run a sweep over different configurations, by providing each configuration as a separate line in an
+"argfile":
+```shell
+launcher bdgpu --argfile sweep-args.txt eval.py --plots
+```
+Where the argfile looks something like this:
+```
+--lr 0.1  --num-steps 10 -o outfile1
+--lr 0.1  --num-steps 15 -o outfile2
+--lr 0.03 --num-steps 10 -o outfile3
+--lr 0.03 --num-steps 15 -o outfile4
+--lr 0.01 --num-steps 10 -o outfile5
+--lr 0.01 --num-steps 15 -o outfile6
+```
+
+In both cases, these will be launched as a [job array](https://slurm.schedmd.com/job_array.html), making it easier to
+track and manage the jobs as a single unit.
+
+## [interact](interact)
+
+This is a wrapper around `srun`. It allows you to easily start an interactive shell on one of the SLURM nodes.  The
+shell you launch will be granted the resources of the [resource config]((#resource-configurations)) you provide.
+
+Example:
+```shell
+interact bdgpu
+```
+
+## [Resource Configurations](config.json)
+
+The `config.json` file provides a list of pre-defined resource configurations which the user can use to launch their
+SLURM jobs. This is helpful to save sets of `sbatch` or `srun` options that the user uses frequently.
+
+Each entry has the following structure:
+```json
 {
   NAME:
     DEVICE 
@@ -57,26 +153,20 @@ where support/device information needs to be provided by ```config.json``` with 
     RESOURCES
 }
 ```
-where NAME is used to select the specs, DEVICE is either "gpu" or "cpu", HOST is either "local" or a remote server name, ENV specifies how to set up virtual environments if needed and RESOURCES specifies the option to pass to SLURM
-e.g.
+
+- `NAME`: a unique identifier for the config.
+- `DEVICE`: either "gpu" or "cpu".
+- `HOST`: either "local" or a remote server name.
+- `ENV`: specifies how to set up virtual environments, if needed.
+- `RESOURCES`: specifies the options to pass to SLURM.
+
+Here is a concrete example:
 ```json
 {
-  "local-gpu": {
-    "device": "gpu",
-    "host": "local",
-    "env": "conda activate deep",
-    "resources": ""
-  },
-  "local-cpu": {
-    "device": "cpu",
-    "host": "local",
-    "env": "conda activate deep",
-    "resources": ""
-  },
   "remote-gpu": {
     "env": "conda activate deep",
     "device": "gpu",
-    "host": "sersver-name",
+    "host": "server-name",
     "resources": {
       "time": "2-00:00:00",
       "account": "lfrati",
@@ -85,14 +175,8 @@ e.g.
       "gres": "gpu:v100:1",
       "mem": "8000"
     }
-  },
-
+  }
 }
 ```
-The script then launches jobs either directly (if support is local) or through a SLURM sbatch file.
-Why also support a local flag? Because it is useful in combination with the --runs flag.
-Since the script uses subprocesses to launch the scripts and awaits them before moving to the next we can easily chain multiple long jobs on a local machine with a single GPU.
-E.g.
-```
-launcher --runs=10 local-gpu dummytrain.py --steps=10
-```
+
+More examples can be found in the [config.json](config.json).

--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ export PATH=$HOME/scratch/neuromanager:$PATH  # ... or wherever your neuromanage
 
 ## [launcher](launcher)
 
-This is a wrapper around `sbatch` to make it way easier to launch python scripts quickly. It allows you to turn:
+This is a wrapper around `sbatch` to make it way easier to launch python scripts quickly. If you would run this locally:
 ```shell
 python train.py --lr=0.01
 ```
-into something like:
+then to run the same thing on the VACC you would do:
+```shell
+launcher dggpu train.py --lr=0.01
+```
+_Voilá!_ Behind the scenes, the launcher created an sbatch script for you like:
 ```bash
 #!/bin/bash
 #SBATCH --time=2-00:00:00

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The `config.json` file provides a list of pre-defined resource configurations wh
 SLURM jobs. This is helpful to save sets of `sbatch` or `srun` options that the user uses frequently.
 
 Each entry has the following structure:
-```json
+```
 {
   NAME:
     DEVICE 

--- a/config.json
+++ b/config.json
@@ -46,7 +46,7 @@
       "partition": "dggpu",
       "gres": "gpu:1",
       "cpus-per-task": 1,
-      "mem": "10G"
+      "mem": "12G"
     }
   },
   "bdgpu": {

--- a/config.json
+++ b/config.json
@@ -58,18 +58,29 @@
       "partition": "bdgpu",
       "gres": "gpu:1",
       "cpus-per-task": 1,
-      "mem": "10G"
+      "mem": "12G"
     }
   },
   "blue": {
-    "env": "conda activate deep",
+    "env": "conda activate neat",
     "device": "cpu",
     "host": "vacc",
     "resources": {
       "time": "1-00:00:00",
       "partition": "bluemoon",
-      "cpus-per-task": 1,
-      "mem": "8000"
+      "cpus-per-task": 32,
+      "mem": "10G"
+    }
+  },
+  "bdneat": {
+    "env": "conda activate neat",
+    "device": "cpu",
+    "host": "vacc",
+    "resources": {
+      "time": "1-00:00:00",
+      "partition": "bdgpu",
+      "cpus-per-task": 32,
+      "mem": "10G"
     }
   }
 }

--- a/config.json
+++ b/config.json
@@ -58,7 +58,7 @@
       "partition": "bdgpu",
       "gres": "gpu:1",
       "cpus-per-task": 1,
-      "mem": "16G"
+      "mem": "10G"
     }
   },
   "blue": {

--- a/config.json
+++ b/config.json
@@ -42,7 +42,7 @@
     "device": "gpu",
     "host": "vacc",
     "resources": {
-      "time": "1-00:00:00",
+      "time": "2-00:00:00",
       "partition": "dggpu",
       "gres": "gpu:1",
       "cpus-per-task": 1,
@@ -50,15 +50,39 @@
     }
   },
   "bdgpu": {
-    "env": "conda activate deep",
+    "env": "conda activate deep-amd",
     "device": "gpu",
     "host": "vacc",
     "resources": {
-      "time": "1-00:00:00",
+      "time": "2-00:00:00",
       "partition": "bdgpu",
       "gres": "gpu:1",
       "cpus-per-task": 1,
-      "mem": "10G"
+      "mem": "12G"
+    }
+  },
+  "dgvega": {
+    "env": "conda activate vega",
+    "device": "gpu",
+    "host": "vacc",
+    "resources": {
+      "time": "2-00:00:00",
+      "partition": "dggpu",
+      "gres": "gpu:2",
+      "cpus-per-task": 4,
+      "mem": "12G"
+    }
+  },
+  "bdvega": {
+    "env": "conda activate vega-amd",
+    "device": "gpu",
+    "host": "vacc",
+    "resources": {
+      "time": "2-00:00:00",
+      "partition": "bdgpu",
+      "gres": "gpu:2",
+      "cpus-per-task": 4,
+      "mem": "12G"
     }
   },
   "blue": {

--- a/config.json
+++ b/config.json
@@ -61,18 +61,6 @@
       "mem": "16G"
     }
   },
-  "bdgpu": {
-    "env": "conda activate deep",
-    "device": "gpu",
-    "host": "vacc",
-    "resources": {
-      "time": "1-00:00:00",
-      "partition": "bdgpu",
-      "gres": "gpu:1",
-      "cpus-per-task": 1,
-      "mem": "8000"
-    }
-  },
   "blue": {
     "env": "conda activate deep",
     "device": "cpu",

--- a/config.json
+++ b/config.json
@@ -46,7 +46,19 @@
       "partition": "dggpu",
       "gres": "gpu:1",
       "cpus-per-task": 1,
-      "mem": "8000"
+      "mem": "10G"
+    }
+  },
+  "bdgpu": {
+    "env": "conda activate deep",
+    "device": "gpu",
+    "host": "vacc",
+    "resources": {
+      "time": "1-00:00:00",
+      "partition": "bdgpu",
+      "gres": "gpu:1",
+      "cpus-per-task": 1,
+      "mem": "16G"
     }
   },
   "bdgpu": {

--- a/config.json
+++ b/config.json
@@ -92,7 +92,7 @@
     "resources": {
       "time": "30:00:00",
       "partition": "bluemoon",
-      "cpus-per-task": 32,
+      "cpus-per-task": 12,
       "mem": "10G"
     }
   },
@@ -103,7 +103,7 @@
     "resources": {
       "time": "48:00:00",
       "partition": "bdgpu",
-      "cpus-per-task": 32,
+      "cpus-per-task": 20,
       "mem": "10G"
     }
   }

--- a/config.json
+++ b/config.json
@@ -90,7 +90,7 @@
     "device": "cpu",
     "host": "vacc",
     "resources": {
-      "time": "1-00:00:00",
+      "time": "30:00:00",
       "partition": "bluemoon",
       "cpus-per-task": 32,
       "mem": "10G"
@@ -101,7 +101,7 @@
     "device": "cpu",
     "host": "vacc",
     "resources": {
-      "time": "1-00:00:00",
+      "time": "48:00:00",
       "partition": "bdgpu",
       "cpus-per-task": 32,
       "mem": "10G"

--- a/interact
+++ b/interact
@@ -1,15 +1,21 @@
 #!/bin/bash
+set -e  # exit on any error
+set -o pipefail  # allow errors in piped commands to bubble up
+
 if [[ $# -ne 1 ]]; then
-        # echo "Usage: interact partition gres"
-        # echo -e "\t partition : parition name, used in --parttion=" 
-        # echo -e "\t gres : gpu resources to request, e.g. --gres=gpu:1" 
-        echo "Usage: interact configuration"
-else 
-	# PARTITION=$1
-	# GRES=$2
-	# srun --partition=$1 --gres=$2 --accel-bind=g --pty bash
+  # echo "Usage: interact partition gres"
+  # echo -e "\t partition : parition name, used in --parttion="
+  # echo -e "\t gres : gpu resources to request, e.g. --gres=gpu:1"
+  echo "Usage: interact <configuration>"
+else
+  # PARTITION=$1
+  # GRES=$2
+  # srun --partition=$1 --gres=$2 --accel-bind=g --pty bash
   echo "Using configuration: $1"
+  # Temporarily run in this script's directory so we can use a relative reference to interact.py.
+  pushd "$(dirname "$(realpath "$0")")" > /dev/null
   CMD=$(python interact.py "$1")
+  popd > /dev/null
   echo "Running: $CMD"
-  $CMD
+  eval "$CMD"
 fi

--- a/launcher
+++ b/launcher
@@ -38,7 +38,7 @@ def slurm_launcher(cmd):
         sub.call(["sbatch", f"{f.name}"], shell=False)
 
 
-def make_slurm_script(conf, cmd, rundir):
+def make_slurm_script(conf, cmd):
     """
     Generate the information to be passed to SLURM about the job
     Also take care of setting up the environment
@@ -52,7 +52,7 @@ def make_slurm_script(conf, cmd, rundir):
     )
     script = f"{shebang}\n{flags}\n\n"
     script += "source ~/.bash_profile\n"  # build the user's environment just as if we spawned a new login shell
-    script += f"cd {rundir}\n"  # run in the same directory as the python script, so relative paths work
+    script += "cd ${SLURM_SUBMIT_DIR}\n"  # run in the same directory as the python script, so relative paths work
     script += f"{conf['env']} && {cmd}"  # activate conda env and launch script if successful
     return script
 
@@ -66,27 +66,51 @@ if __name__ == "__main__":
         )
 
     parser = argparse.ArgumentParser(prog="neurun")
-    parser.add_argument("resource")
+    parser.add_argument(
+        "resource",
+        help="Identifier of the resource configuration to use. Must be one of the configs present in config.json.",
+    )
     parser.add_argument(
         "--runs",
         type=int,
         help="How many repetitions to run.",
         default=1,
     )
-    parser.add_argument("entry")
-    parser.add_argument("flags", nargs=argparse.REMAINDER)
+    parser.add_argument(
+        "-d",
+        "--rundir",
+        help="The directory from which to launch the script. Slurm output will be directed here.",
+    )
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Launch a new job even if another job has already used this output directory. Does not remove the"
+        " previous output log, and only needed when specifying --rundir.",
+    )
+    parser.add_argument("entry", help="The python script to launch.")
+    parser.add_argument("flags", nargs=argparse.REMAINDER, help="Flags to be passed to the python script.")
     args = parser.parse_args()
 
+    ################# VALIDATE INPUT #################
     # Find config file in the same folder as this launcher script.
     config_file = Path(__file__).parent / "config.json"
     print(args)
-    print("File:", args.entry)
-    print("Flags:", args.flags)
 
-    ################# VALIDATE INPUT #################
+    if args.rundir:
+        rundir = Path(args.rundir)
+        rundir.mkdir(exist_ok=True)
+        if not args.force and list(rundir.glob("slurm-*.out")):
+            parser.error(f"A Slurm output file already exists in the target directory: {rundir.resolve()}.\nUse"
+                         " -f/--force to run in this folder anyway.")
+    else:
+        rundir = Path(".")
+
     entry_path = Path(args.entry).resolve()
-    assert entry_path.exists(), f"File {args.entry} not found."
+    assert entry_path.exists(), f"File {entry_path} not found."
+    assert entry_path.is_file(), f"File {entry_path} is not a file."
     assert config_file.exists(), f"Configuration file ({config_file}) not found."
+    assert config_file.is_file(), f"Configuration file ({config_file}) is not a file."
     with open(config_file, "r") as f:
         available_configs = json.loads(f.read())
     assert (
@@ -101,11 +125,14 @@ if __name__ == "__main__":
     ], f"Wrong device requested: {device} not in [cpu, gpu]"
     ##################################################
 
+    os.chdir(rundir)
+    print("Running from:", rundir.resolve())
+    print("File:", entry_path)
+    print("Flags:", args.flags)
     print("Config:\n", json.dumps(config, indent=2, sort_keys=True))
 
     cmd = f"time python {entry_path} {' '.join(args.flags)}"
-    rundir = entry_path.parent
-    scripts = [make_slurm_script(config, cmd, rundir) for _ in range(args.runs)]
+    scripts = [make_slurm_script(config, cmd) for _ in range(args.runs)]
 
     for i, script in enumerate(scripts):
         slurm_launcher(script)

--- a/launcher
+++ b/launcher
@@ -76,6 +76,7 @@ def make_slurm_script(conf, cmd):
     script = f"{shebang}\n{flags}\n\n"
     script += "source ~/.bash_profile\n"  # build the user's environment just as if we spawned a new login shell
     script += "cd ${SLURM_SUBMIT_DIR}\n"  # run in the same directory as the python script, so relative paths work
+    script += f"echo 'Command: {cmd}'\n"  # print the command we're about to run
     script += f"{conf['env']} && {cmd}"  # activate conda env and launch script if successful
     return script
 

--- a/launcher
+++ b/launcher
@@ -1,20 +1,16 @@
 #!/usr/bin/env python
 """
 Utility to launch a python script on SLURM, using CPU or GPU. Uses configuration
-information from config.json and supports launching multiple repeats.
+information from config.json and supports launching sweeps or repeats.
 
 Flags can be passed to the delegated script by appending them at the end as follows
-    > launcher RESOURCE {--runs} SCRIPT FLAGS
-e.g.
-    > launcher moran-gpu --runs=2 dummy_gpujob.py --epochs=10 --seed 42
+    > launcher <resource> [--runs] <script> [<flags>...]
+For example, this:
+    > launcher moran-gpu --runs 2 dummy_gpujob.py --epochs=10 --seed 42
 is equivalent to twice running this:
     > python dummy_gpujob.py --epochs=10 --seed 42
 
 Furthermore, any settings accepted by `sbatch` may be supplied on the command line.
-These will override the options provided by config.json, if given. For example, to
-add more memory to an existing config:
-    > launcher dggpu --mem=64G dummy_gpujob.py --epochs=10 --seed 42
-
 IMPORTANT: The sbatch options must be supplied in "--name=value" fashion, with an
 equals sign; "--name value" will NOT parse correctly. For any other options
 (including script flags) you may use either format.
@@ -26,6 +22,7 @@ import tempfile
 import json
 import os
 import subprocess as sub
+import sys
 from pathlib import Path
 
 DEBUG = os.getenv("DEBUG", None) is not None
@@ -50,12 +47,12 @@ def slurm_launcher(cmd, sbatch_args):
         sbatch_cmd = ["sbatch"] + sbatch_args + ["<file>"]
         print(" ".join(sbatch_cmd))
         print()
-        return
+        return 0
 
     with tempfile.NamedTemporaryFile() as f:
         f.write(cmd.encode("utf-8"))
         f.flush()
-        sub.call(["sbatch"] + sbatch_args + [f"{f.name}"], shell=False)
+        return sub.call(["sbatch"] + sbatch_args + [f"{f.name}"], shell=False)
 
 
 def make_slurm_script(conf, cmd, argfile, num_runs):
@@ -110,15 +107,68 @@ def make_slurm_script(conf, cmd, argfile, num_runs):
     return script
 
 
+def validate_and_setup(parser, args):
+    """
+    Validate command line arguments, and setup files for input/output.
+    """
+    # Find config file in the same folder as this launcher script.
+    config_file = Path(__file__).parent / "config.json"
+    assert config_file.exists(), f"Configuration file ({config_file}) not found."
+    assert config_file.is_file(), f"Configuration file ({config_file}) is not a file."
+    print(args)
+
+    with open(config_file, "r") as f:
+        available_configs = json.loads(f.read())
+    if args.resource not in available_configs.keys():
+        parser.error(f"Requested resource ({args.resource}) not found in config file ({config_file}).")
+    config = available_configs[args.resource]
+    device = config["device"]
+    devlist = ["cpu", "gpu"]
+    assert device in devlist, f"Wrong device requested: {device} not in {devlist}."
+
+    # Set up destination directory.
+    if args.rundir:
+        args.rundir = Path(args.rundir).resolve()
+        if not DEBUG:
+            args.rundir.mkdir(exist_ok=True, parents=True)
+        if not args.force and list(args.rundir.glob("slurm-*.out")):
+            parser.error(f"A Slurm output file already exists in the target directory: {args.rundir.resolve()}.\nUse"
+                         " -f/--force to run in this folder anyway.")
+    else:
+        args.rundir = Path(".").resolve()
+
+    # Copy argfile to destination if not already there (do this last so we don't copy it needlessly when the above
+    # chacks fail).
+    if args.argfile and args.argfile.parent != args.rundir:
+        destfile = args.rundir / args.argfile.name
+        if not args.force and destfile.exists():
+            parser.error(f"Argfile already exists in the target directory: {destfile}.\nUse -f/--force to overwrite.")
+        if not DEBUG:
+            shutil.copy(args.argfile, args.rundir)
+            args.argfile = destfile
+        else:
+            print(f"Would copy {args.argfile} into {args.rundir}.")
+
+    return config
+
+
 def check_path(path):
     pathobj = Path(path)
     if pathobj.exists():
         return pathobj.resolve()
     else:
-        raise argparse.ArgumentTypeError(f"{path} is not a valid path.")
+        raise argparse.ArgumentTypeError(f"Not a valid path: {path}")
 
 
-if __name__ == "__main__":
+def check_file(path):
+    pathobj = check_path(path)
+    if pathobj.is_file():
+        return pathobj
+    else:
+        raise argparse.ArgumentTypeError(f"Exists, but not a file: {path}")
+
+
+def main(args=None):
 
     if DEBUG:
         print(
@@ -132,6 +182,7 @@ if __name__ == "__main__":
         help="Identifier of the resource configuration to use. Must be one of the configs present in config.json.",
     )
     parser.add_argument(
+        "-r",
         "--runs",
         type=int,
         default=1,
@@ -157,63 +208,23 @@ if __name__ == "__main__":
         help="Launch a new job even if another job has already used this output directory. Does not remove the"
         " previous output log, and only needed when specifying --rundir.",
     )
-    parser.add_argument("entry", help="The python script to launch.")
+    parser.add_argument("script", type=check_file, help="The python script to launch.")
     parser.add_argument("flags", nargs=argparse.REMAINDER, help="Flags to be passed to the python script.")
-    args, sbatch_args = parser.parse_known_args()
+    args, sbatch_args = parser.parse_known_args(args)
 
-    ################# VALIDATE INPUT #################
-    # Find config file in the same folder as this launcher script.
-    config_file = Path(__file__).parent / "config.json"
-    print(args)
-
-    entry_path = Path(args.entry).resolve()
-    assert entry_path.exists(), f"File {entry_path} not found."
-    assert entry_path.is_file(), f"File {entry_path} is not a file."
-    assert config_file.exists(), f"Configuration file ({config_file}) not found."
-    assert config_file.is_file(), f"Configuration file ({config_file}) is not a file."
-    with open(config_file, "r") as f:
-        available_configs = json.loads(f.read())
-    assert (
-        args.resource in available_configs.keys()
-    ), f"Requested configuration ({args.resource}) not found in config file ({config_file})"
-
-    config = available_configs[args.resource]
-    device = config["device"]
-    devlist = ["cpu", "gpu"]
-    assert device in devlist, f"Wrong device requested: {device} not in {devlist}."
-
-    # Set up destination directory.
-    if args.rundir:
-        rundir = Path(args.rundir).resolve()
-        if not DEBUG:
-            rundir.mkdir(exist_ok=True, parents=True)
-        if not args.force and list(rundir.glob("slurm-*.out")):
-            parser.error(f"A Slurm output file already exists in the target directory: {rundir.resolve()}.\nUse"
-                         " -f/--force to run in this folder anyway.")
-    else:
-        rundir = Path(".").resolve()
-
-    # Copy argfile to destination if not already there (do this last so we don't copy it needlessly when the above
-    # chacks fail).
-    if args.argfile and args.argfile.parent != rundir:
-        destfile = rundir / args.argfile.name
-        if not args.force and destfile.exists():
-            parser.error(f"Argfile already exists in the target directory: {destfile}.\nUse -f/--force to overwrite.")
-        if not DEBUG:
-            shutil.copy(args.argfile, rundir)
-            args.argfile = destfile
-        else:
-            print(f"Would copy {args.argfile} into {rundir}.")
-
-    ##################################################
+    config = validate_and_setup(parser, args)
 
     if not DEBUG:
-        os.chdir(rundir)
-    print("Running from:", rundir.resolve())
-    print("File:", entry_path)
+        os.chdir(args.rundir)
+    print("Running from:", args.rundir.resolve())
+    print("Python script:", args.script)
     print("Flags:", args.flags)
     print("Config:\n", json.dumps(config, indent=2, sort_keys=True))
 
-    cmd = f"time python {entry_path} {' '.join(args.flags)}"
+    cmd = f"time python {args.script} {' '.join(args.flags)}"
     script = make_slurm_script(config, cmd, args.argfile, args.runs)
-    slurm_launcher(script, sbatch_args)
+    return slurm_launcher(script, sbatch_args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/launcher
+++ b/launcher
@@ -12,11 +12,12 @@ import argparse
 import tempfile
 import json
 import os
-from tqdm import tqdm
-from uuid import uuid4
-from datetime import date
 import subprocess as sub
+from datetime import date
 from pathlib import Path
+from uuid import uuid4
+
+from tqdm import tqdm
 
 DEBUG = os.getenv("DEBUG", None) is not None
 
@@ -26,7 +27,9 @@ def slurm_launcher(cmd):
     Create a temp file with the slurm sbatch syntax, launch it and then delete it
     """
     if DEBUG:
+        print("\n#### OUTPUT SCRIPT ####")
         print(cmd)
+        print()
         return
 
     with tempfile.NamedTemporaryFile() as f:
@@ -35,20 +38,22 @@ def slurm_launcher(cmd):
         sub.call(["sbatch", f"{f.name}"], shell=False)
 
 
-def make_slurm_script(conf, cmd):
+def make_slurm_script(conf, cmd, rundir):
     """
     Generate the information to be passed to SLURM about the job
     Also take care of setting up the environment
     The python command will be added afterwards
     """
+    # The shebang is not needed by slurm, but can be useful if we want to try running the script
+    # ourselves.
     shebang = "#!/bin/bash"
     flags = "\n".join(
         f"#SBATCH --{flag}={value}" for flag, value in conf["resources"].items()
     )
     script = f"{shebang}\n{flags}\n\n"
-    script += "source ~/.bashrc\n"  # needed to conda activate and stuff
-    script += "cd ${SLURM_SUBMIT_DIR}\n"  # sbatch spawns you in the home
-    script += f"{conf['env']}\n{cmd}"  # activate conda env and launch script
+    script += "source ~/.bash_profile\n"  # build the user's environment just as if we spawned a new login shell
+    script += f"cd {rundir}\n"  # run in the same directory as the python script, so relative paths work
+    script += f"{conf['env']} && {cmd}"  # activate conda env and launch script if successful
     return script
 
 
@@ -72,14 +77,16 @@ if __name__ == "__main__":
     parser.add_argument("flags", nargs=argparse.REMAINDER)
     args = parser.parse_args()
 
-    config_file = "config.json"
+    # Find config file in the same folder as this launcher script.
+    config_file = Path(__file__).parent / "config.json"
     print(args)
     print("File:", args.entry)
     print("Flags:", args.flags)
 
     ################# VALIDATE INPUT #################
-    assert Path(args.entry).exists(), f"File {args.entry} not found."
-    assert Path(config_file).exists(), f"Configuration file ({config_file}) not found."
+    entry_path = Path(args.entry).resolve()
+    assert entry_path.exists(), f"File {args.entry} not found."
+    assert config_file.exists(), f"Configuration file ({config_file}) not found."
     with open(config_file, "r") as f:
         available_configs = json.loads(f.read())
     assert (
@@ -96,9 +103,9 @@ if __name__ == "__main__":
 
     print("Config:\n", json.dumps(config, indent=2, sort_keys=True))
 
-    cmd = f"python {args.entry} {' '.join(args.flags)}"
-
-    scripts = [make_slurm_script(config, cmd) for _ in range(args.runs)]
+    cmd = f"time python {entry_path} {' '.join(args.flags)}"
+    rundir = entry_path.parent
+    scripts = [make_slurm_script(config, cmd, rundir) for _ in range(args.runs)]
 
     for i, script in enumerate(scripts):
         slurm_launcher(script)

--- a/launcher
+++ b/launcher
@@ -131,11 +131,12 @@ def validate_and_setup(parser, args):
         args.rundir = Path(args.rundir).resolve()
         if not DEBUG:
             args.rundir.mkdir(exist_ok=True, parents=True)
-        if not args.force and list(args.rundir.glob("slurm-*.out")):
-            parser.error(f"A Slurm output file already exists in the target directory: {args.rundir.resolve()}.\nUse"
-                         " -f/--force to run in this folder anyway.")
     else:
         args.rundir = Path(".").resolve()
+
+    if not args.force and list(args.rundir.glob("slurm-*.out")):
+        parser.error(f"A Slurm output file already exists in the target directory: {args.rundir.resolve()}.\n"
+                     "Use -f/--force to run in this folder anyway.")
 
     # Copy argfile to destination if not already there (do this last so we don't copy it needlessly when the above
     # chacks fail).

--- a/launcher
+++ b/launcher
@@ -92,9 +92,9 @@ def make_slurm_script(conf, cmd, argfile, num_runs):
 
     # Shell commands
     script += "\n"
-    script += "set -e\n"  # exit if any command fails
-    script += "set -o pipefail\n"  # cause errors within a series of piped commands to bubble to the surface
     script += "source ~/.bash_profile\n"  # build the user's environment just as if we spawned a new login shell
+    script += "set -e\n"  # exit if any command fails (IMPORTANT: only set this after shell setup)
+    script += "set -o pipefail\n"  # cause errors within a series of piped commands to bubble to the surface
     script += "cd ${SLURM_SUBMIT_DIR}\n"  # run in the same directory as the python script, so relative paths work
     script += f'CMD="{cmd}"\n'
     if argfile:

--- a/launcher
+++ b/launcher
@@ -1,11 +1,23 @@
 #!/usr/bin/env python
 """
-Utility to launch a python script on SLURM, using CPU or GPU.
-Uses configuration information from config.json and supports launching multiple repeats.
-Flags can be passed to the script name by appending them at the end as follows
-> launcher RESOURCE {--runs} SCRIPT FLAGS
+Utility to launch a python script on SLURM, using CPU or GPU. Uses configuration
+information from config.json and supports launching multiple repeats.
+
+Flags can be passed to the delegated script by appending them at the end as follows
+    > launcher RESOURCE {--runs} SCRIPT FLAGS
 e.g.
-> launcher moran-gpu --runs=2 dummy_gpujob.py --steps=10
+    > launcher moran-gpu --runs=2 dummy_gpujob.py --epochs=10 --seed 42
+is equivalent to twice running this:
+    > python dummy_gpujob.py --epochs=10 --seed 42
+
+Furthermore, any settings accepted by `sbatch` may be supplied on the command line.
+These will override the options provided by config.json, if given. For example, to
+add more memory to an existing config:
+    > launcher dggpu --mem=64G dummy_gpujob.py --epochs=10 --seed 42
+
+IMPORTANT: The sbatch options must be supplied in "--name=value" fashion, with an
+equals sign; "--name value" will NOT parse correctly. For any other options
+(including script flags) you may use either format.
 """
 
 import argparse
@@ -22,20 +34,31 @@ from tqdm import tqdm
 DEBUG = os.getenv("DEBUG", None) is not None
 
 
-def slurm_launcher(cmd):
+class HelpFormatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+    """
+    This class adds no new functionality, only is used to combine the existing functionality of two different
+    formatters through multiple inheritance.
+    """
+    pass
+
+
+def slurm_launcher(cmd, sbatch_args):
     """
     Create a temp file with the slurm sbatch syntax, launch it and then delete it
     """
     if DEBUG:
         print("\n#### OUTPUT SCRIPT ####")
         print(cmd)
+        print("\n#### SBATCH CALL ####")
+        sbatch_cmd = ["sbatch"] + sbatch_args + ["<file>"]
+        print(" ".join(sbatch_cmd))
         print()
         return
 
     with tempfile.NamedTemporaryFile() as f:
         f.write(cmd.encode("utf-8"))
         f.flush()
-        sub.call(["sbatch", f"{f.name}"], shell=False)
+        sub.call(["sbatch"] + sbatch_args + [f"{f.name}"], shell=False)
 
 
 def make_slurm_script(conf, cmd):
@@ -65,7 +88,7 @@ if __name__ == "__main__":
             "#####################\n"
         )
 
-    parser = argparse.ArgumentParser(prog="neurun")
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=HelpFormatter)
     parser.add_argument(
         "resource",
         help="Identifier of the resource configuration to use. Must be one of the configs present in config.json.",
@@ -90,7 +113,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("entry", help="The python script to launch.")
     parser.add_argument("flags", nargs=argparse.REMAINDER, help="Flags to be passed to the python script.")
-    args = parser.parse_args()
+    args, sbatch_args = parser.parse_known_args()
 
     ################# VALIDATE INPUT #################
     # Find config file in the same folder as this launcher script.
@@ -99,7 +122,8 @@ if __name__ == "__main__":
 
     if args.rundir:
         rundir = Path(args.rundir)
-        rundir.mkdir(exist_ok=True)
+        if not DEBUG:
+            rundir.mkdir(exist_ok=True, parents=True)
         if not args.force and list(rundir.glob("slurm-*.out")):
             parser.error(f"A Slurm output file already exists in the target directory: {rundir.resolve()}.\nUse"
                          " -f/--force to run in this folder anyway.")
@@ -125,7 +149,8 @@ if __name__ == "__main__":
     ], f"Wrong device requested: {device} not in [cpu, gpu]"
     ##################################################
 
-    os.chdir(rundir)
+    if not DEBUG:
+        os.chdir(rundir)
     print("Running from:", rundir.resolve())
     print("File:", entry_path)
     print("Flags:", args.flags)
@@ -135,4 +160,4 @@ if __name__ == "__main__":
     scripts = [make_slurm_script(config, cmd) for _ in range(args.runs)]
 
     for i, script in enumerate(scripts):
-        slurm_launcher(script)
+        slurm_launcher(script, sbatch_args)

--- a/launcher
+++ b/launcher
@@ -21,15 +21,12 @@ equals sign; "--name value" will NOT parse correctly. For any other options
 """
 
 import argparse
+import shutil
 import tempfile
 import json
 import os
 import subprocess as sub
-from datetime import date
 from pathlib import Path
-from uuid import uuid4
-
-from tqdm import tqdm
 
 DEBUG = os.getenv("DEBUG", None) is not None
 
@@ -44,7 +41,7 @@ class HelpFormatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefau
 
 def slurm_launcher(cmd, sbatch_args):
     """
-    Create a temp file with the slurm sbatch syntax, launch it and then delete it
+    Create a temp file with the slurm sbatch syntax, launch it and then delete it.
     """
     if DEBUG:
         print("\n#### OUTPUT SCRIPT ####")
@@ -61,24 +58,64 @@ def slurm_launcher(cmd, sbatch_args):
         sub.call(["sbatch"] + sbatch_args + [f"{f.name}"], shell=False)
 
 
-def make_slurm_script(conf, cmd):
+def make_slurm_script(conf, cmd, argfile, num_runs):
     """
-    Generate the information to be passed to SLURM about the job
-    Also take care of setting up the environment
-    The python command will be added afterwards
+    Generate the information to be passed to SLURM about the job.
+    Also take care of setting up the environment.
+    The python command will be added afterwards.
     """
+    if argfile:
+        # Count the number of arg lines in the arg file.
+        with argfile.open() as f:
+            num_runs = 0
+            has_blank = False
+            for i, line in enumerate(f):
+                if line.strip():
+                    # This is a non-blank line.
+                    num_runs += 1
+                    # If a non-blank follows any blank line...
+                    if has_blank:
+                        raise RuntimeError("Argfile cannot have blank lines, except at the end of the file. Found"
+                                           f" blank at line {i-1}.")
+                else:
+                    has_blank = True
+    if num_runs < 1:
+        raise ValueError(f"num_runs should be a positive number, but is {num_runs} instead.")
+
     # The shebang is not needed by slurm, but can be useful if we want to try running the script
     # ourselves.
-    shebang = "#!/bin/bash"
-    flags = "\n".join(
-        f"#SBATCH --{flag}={value}" for flag, value in conf["resources"].items()
-    )
-    script = f"{shebang}\n{flags}\n\n"
+    script = "#!/bin/bash\n"
+
+    # sbatch flags
+    for flag, value in conf["resources"].items():
+        script += f"#SBATCH --{flag}={value}\n"
+    if num_runs > 1:
+        # If we have multiple jobs, launch them as an array.
+        script += f"#SBATCH --array=1-{num_runs}\n"
+
+    # Shell commands
+    script += "\n"
+    script += "set -e\n"  # exit if any command fails
+    script += "set -o pipefail\n"  # cause errors within a series of piped commands to bubble to the surface
     script += "source ~/.bash_profile\n"  # build the user's environment just as if we spawned a new login shell
     script += "cd ${SLURM_SUBMIT_DIR}\n"  # run in the same directory as the python script, so relative paths work
-    script += f"echo 'Command: {cmd}'\n"  # print the command we're about to run
-    script += f"{conf['env']} && {cmd}"  # activate conda env and launch script if successful
+    script += f'CMD="{cmd}"\n'
+    if argfile:
+        # Takes the Nth line from the argfile as additional args for the command.
+        script += f'ARGLIST="$(head -$SLURM_ARRAY_TASK_ID {argfile} | tail -1)"\n'
+        script += 'CMD="$CMD $ARGLIST"\n'
+    script += 'echo "Command: $CMD"\n'  # print the command we're about to run
+    script += conf["env"] + "\n"  # activate conda env
+    script += f'eval "$CMD"\n'  # finally, launch program
     return script
+
+
+def check_path(path):
+    pathobj = Path(path)
+    if pathobj.exists():
+        return pathobj.resolve()
+    else:
+        raise argparse.ArgumentTypeError(f"{path} is not a valid path.")
 
 
 if __name__ == "__main__":
@@ -97,12 +134,20 @@ if __name__ == "__main__":
     parser.add_argument(
         "--runs",
         type=int,
-        help="How many repetitions to run.",
         default=1,
+        help="How many repetitions to run. This will result in an array of jobs, rather than a single job.",
+    )
+    parser.add_argument(
+        "--argfile",
+        type=check_path,
+        help="A file containing a list of argument strings, one per job. This will result in an array of jobs, where"
+             " each job corresponds to a single line of this file. The args in the file are tacked onto the end of the"
+             " command given. If this argument is present, --runs will be ignored.",
     )
     parser.add_argument(
         "-d",
         "--rundir",
+        type=Path,
         help="The directory from which to launch the script. Slurm output will be directed here.",
     )
     parser.add_argument(
@@ -121,16 +166,6 @@ if __name__ == "__main__":
     config_file = Path(__file__).parent / "config.json"
     print(args)
 
-    if args.rundir:
-        rundir = Path(args.rundir)
-        if not DEBUG:
-            rundir.mkdir(exist_ok=True, parents=True)
-        if not args.force and list(rundir.glob("slurm-*.out")):
-            parser.error(f"A Slurm output file already exists in the target directory: {rundir.resolve()}.\nUse"
-                         " -f/--force to run in this folder anyway.")
-    else:
-        rundir = Path(".")
-
     entry_path = Path(args.entry).resolve()
     assert entry_path.exists(), f"File {entry_path} not found."
     assert entry_path.is_file(), f"File {entry_path} is not a file."
@@ -144,10 +179,32 @@ if __name__ == "__main__":
 
     config = available_configs[args.resource]
     device = config["device"]
-    assert device in [
-        "cpu",
-        "gpu",
-    ], f"Wrong device requested: {device} not in [cpu, gpu]"
+    devlist = ["cpu", "gpu"]
+    assert device in devlist, f"Wrong device requested: {device} not in {devlist}."
+
+    # Set up destination directory.
+    if args.rundir:
+        rundir = Path(args.rundir).resolve()
+        if not DEBUG:
+            rundir.mkdir(exist_ok=True, parents=True)
+        if not args.force and list(rundir.glob("slurm-*.out")):
+            parser.error(f"A Slurm output file already exists in the target directory: {rundir.resolve()}.\nUse"
+                         " -f/--force to run in this folder anyway.")
+    else:
+        rundir = Path(".").resolve()
+
+    # Copy argfile to destination if not already there (do this last so we don't copy it needlessly when the above
+    # chacks fail).
+    if args.argfile and args.argfile.parent != rundir:
+        destfile = rundir / args.argfile.name
+        if not args.force and destfile.exists():
+            parser.error(f"Argfile already exists in the target directory: {destfile}.\nUse -f/--force to overwrite.")
+        if not DEBUG:
+            shutil.copy(args.argfile, rundir)
+            args.argfile = destfile
+        else:
+            print(f"Would copy {args.argfile} into {rundir}.")
+
     ##################################################
 
     if not DEBUG:
@@ -158,7 +215,5 @@ if __name__ == "__main__":
     print("Config:\n", json.dumps(config, indent=2, sort_keys=True))
 
     cmd = f"time python {entry_path} {' '.join(args.flags)}"
-    scripts = [make_slurm_script(config, cmd) for _ in range(args.runs)]
-
-    for i, script in enumerate(scripts):
-        slurm_launcher(script, sbatch_args)
+    script = make_slurm_script(config, cmd, args.argfile, args.runs)
+    slurm_launcher(script, sbatch_args)


### PR DESCRIPTION
After this change, if we have the Neuromanager tools on our PATH, we can simply go to our `higherANML` repo and run:
```
launcher dggpu train_omni.py --epochs 100
```
so that it mirrors the way we would run locally:
```
python train_omni.py --epochs 100
```
We can similarly run it from anywhere.

The script will be launched from whatever folder we call `launcher` from, _or_ the user can explicitly specify the run directory using `--rundir`. So now we can run different experiments something like this:
```
launcher dggpu -d experiments/lr-01 train_omni.py --lr 0.1
launcher dggpu -d experiments/lr-005 train_omni.py --lr 0.05
```
... and both `slurm-*.out` and `trained_anmls` will end up in the same directory, for easy reference.

----

Detailed changes:
- Source `~/.bash_profile`, as we would expect when starting a new ssh session.
- Run python script within the same folder where it resides, so that relative paths in the python script work.
- Resolve scripts provided as relative paths.
- Look for config in same folder as `launcher`. This allows us to run launcher from other folders.
- Add ability to specify directory to run in.

Example output:
```shell
(deep) ntraft@vacc-user2:higherANML $ launcher dggpu -d experiments/test-exp train_omni.py --epochs 10                                                                                                                                        
Namespace(entry='train_omni.py', flags=['--epochs', '10'], force=False, resource='dggpu', rundir='experiments/test-exp', runs=1)
usage: neurun [-h] [--runs RUNS] [-d RUNDIR] [-f] resource entry ...
neurun: error: A Slurm output file already exists in the target directory: /gpfs1/home/n/t/ntraft/Development/higherANML/experiments/test-exp.
Use -f/--force to run in this folder anyway.
(deep) ntraft@vacc-user2:higherANML $ launcher dggpu -d experiments/test-exp -f train_omni.py --epochs 10                                                                                                                                     
Namespace(entry='train_omni.py', flags=['--epochs', '10'], force=True, resource='dggpu', rundir='experiments/test-exp', runs=1)
Running from: /gpfs1/home/n/t/ntraft/Development/higherANML/experiments/test-exp/experiments/test-exp
File: /gpfs1/home/n/t/ntraft/Development/higherANML/train_omni.py
Flags: ['--epochs', '10']
Config:
 {
  "device": "gpu",
  "env": "conda activate deep",
  "host": "vacc",
  "resources": {
    "cpus-per-task": 1,
    "gres": "gpu:1",
    "mem": "10G",
    "partition": "dggpu",
    "time": "1-00:00:00"
  }
}
Submitted batch job 6506809
```